### PR TITLE
Added The Missing Boots Check

### DIFF
--- a/src/PocketMineItalianDevs/TapToArmor/Main.php
+++ b/src/PocketMineItalianDevs/TapToArmor/Main.php
@@ -67,7 +67,7 @@ class Main extends PluginBase implements Listener{
 			$copy = $player->getArmorInventory()->getLeggings();
 			$set = $player->getArmorInventory()->setLeggings($armor);
 		}
-		else{
+		elseif(in_array($id, self::BOOTS, true)){
 			$copy = $player->getArmorInventory()->getBoots();
 			$set = $player->getArmorInventory()->setBoots($armor);
 		}
@@ -84,7 +84,7 @@ class Main extends PluginBase implements Listener{
 	 */
 	public function onInteract(PlayerInteractEvent $event) : void{
 		if(($event->getAction() === PlayerInteractEvent::RIGHT_CLICK_AIR or $event->getAction() === PlayerInteractEvent::RIGHT_CLICK_BLOCK) and ($event->getItem() instanceof Armor or $event->getItem()->getId() === Item::ELYTRA) and $event->getBlock()->getId() !== Block::ITEM_FRAME_BLOCK){
-			$this->setArmorByType($event->getItem(), $event->getPlayer());
+				$this->setArmorByType($event->getItem(), $event->getPlayer());
 			$event->setCancelled(true);
 		}
 	}

--- a/src/PocketMineItalianDevs/TapToArmor/Main.php
+++ b/src/PocketMineItalianDevs/TapToArmor/Main.php
@@ -84,7 +84,7 @@ class Main extends PluginBase implements Listener{
 	 */
 	public function onInteract(PlayerInteractEvent $event) : void{
 		if(($event->getAction() === PlayerInteractEvent::RIGHT_CLICK_AIR or $event->getAction() === PlayerInteractEvent::RIGHT_CLICK_BLOCK) and ($event->getItem() instanceof Armor or $event->getItem()->getId() === Item::ELYTRA) and $event->getBlock()->getId() !== Block::ITEM_FRAME_BLOCK){
-				$this->setArmorByType($event->getItem(), $event->getPlayer());
+			$this->setArmorByType($event->getItem(), $event->getPlayer());
 			$event->setCancelled(true);
 		}
 	}


### PR DESCRIPTION
This is a sanity check to prevent unrelated non matching items get forcefully equipped as leggings
Item begin `Armor` does not also ensure it's an ID in the aforementioned arrays, assuming so THEN using boots as a "fallback" is a bad practice
And can lead to unintended consequences...

Example, what if i made my own plugin that register pumpkin as armor, now if i click with it in hand?
Your plugin would EXPECT `$item instanceof Armor` to means it MUST be vanilla implemented items,
That will be found in your predefined array, and pass it to `setArmorByType()`

It's all good and fine until now, but since pumpkin isnt in any of the arrays, and you used the boots as a fallback array
Now players are running around wearing pumpkins as boots!!!
Same thing can happen if i assume implement anything as armor, not saying you have the responsibility to handle equipping it,
But at the very least, your plugin should not to fall into an "undefined state"

TLDR: using "implied constraints"(instanceof armor, implies it is armor) in conjunction of using the last condition as "deduced match"(deducing, if it isnt helm, chest, leg, it MUST be boots) isnt a good idea